### PR TITLE
fix SSR generate fail when search page is disabled

### DIFF
--- a/lib/generator/entries/index.js
+++ b/lib/generator/entries/index.js
@@ -19,7 +19,7 @@ module.exports = function (locals) {
 
   // Cache page routes for ssr
   if (theme.seo.ssr)
-    theme.runtime.generatedRoutes = ret.filter(i => i && i.layout === 'index').map(i => i.path);
+    theme.runtime.generatedRoutes = ret.filter(i => i?.layout === 'index').map(i => i.path);
 
   return ret;
 };

--- a/lib/generator/entries/index.js
+++ b/lib/generator/entries/index.js
@@ -19,7 +19,7 @@ module.exports = function (locals) {
 
   // Cache page routes for ssr
   if (theme.seo.ssr)
-    theme.runtime.generatedRoutes = ret.filter(i => i.layout === 'index').map(i => i.path);
+    theme.runtime.generatedRoutes = ret.filter(i => i && i.layout === 'index').map(i => i.path);
 
   return ret;
 };


### PR DESCRIPTION
Set `search.page` to false, and `seo.ssr` to true will cause

```
TypeError: Cannot read properties of undefined (reading 'layout')
    at /home/runner/work/test-hexo-theme-inside/test-hexo-theme-inside/node_modules/hexo-theme-inside/lib/generator/entries/index.js:22:55
```

https://github.com/mercury233/test-hexo-theme-inside/actions/runs/3349722532/jobs/5549981151#step:5:13