### PR TITLE
fix(deps): update `htmlToText` method in `lib/config.js`

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -216,7 +216,7 @@ module.exports = function (hexo) {
 
         return (content) => {
           const words = utils.countWord(
-            htmlToText.fromString(content, {
+            htmlToText.convert(content, {
               ignoreImage: false,
               ignoreHref: true,
               wordwrap: false,


### PR DESCRIPTION
- Replace `htmlToText.fromString` with `htmlToText.convert` in `lib/config.js`.
- function `htmlToText.fromString` deprecated in htmlToText@8.0.0, 和 use `htmlToText.convert` instead.
- I test in my local hexo blog, and `hexo server` work after change the function.
- Close #347 as fixed.

My latest `package.json` is:
- hexo: 7.3.0
- hexo-theme-inside: 2.7.1 with modify